### PR TITLE
ENG-287: rename puzzle components

### DIFF
--- a/components/thumbnail-grid/dropdown.tsx
+++ b/components/thumbnail-grid/dropdown.tsx
@@ -7,7 +7,7 @@ import ChevronDownIcon from "@heroicons/react/solid/ChevronDownIcon";
 
 import { PAGINATION_COUNTS } from "@lib/constants";
 
-interface PuzzlesDropdownProps {
+interface DropdownProps {
   currentCount: number;
   urlBase: string;
 }
@@ -32,7 +32,7 @@ const DropdownLink = forwardRef<HTMLAnchorElement, DropdownLinkProps>(
 
 DropdownLink.displayName = "DropdownLink";
 
-const PuzzlesDropdown = ({ currentCount, urlBase }: PuzzlesDropdownProps) => {
+const Dropdown = ({ currentCount, urlBase }: DropdownProps) => {
   return (
     <Menu as="div" className="relative inline-block text-left ml-5 z-10">
       <div>
@@ -55,14 +55,14 @@ const PuzzlesDropdown = ({ currentCount, urlBase }: PuzzlesDropdownProps) => {
           <div className="">
             {PAGINATION_COUNTS.map((count) => {
               const selectedCount = currentCount === count;
-              const [smallestPuzzleCount] = PAGINATION_COUNTS;
+              const [smallestThumbnailCount] = PAGINATION_COUNTS;
 
               return (
                 <Menu.Item key={count} disabled={selectedCount}>
                   {({ active }) => (
                     <DropdownLink
                       href={
-                        count === smallestPuzzleCount
+                        count === smallestThumbnailCount
                           ? urlBase
                           : `${urlBase}/${count}/1`
                       }
@@ -90,4 +90,4 @@ const PuzzlesDropdown = ({ currentCount, urlBase }: PuzzlesDropdownProps) => {
   );
 };
 
-export default PuzzlesDropdown;
+export default Dropdown;

--- a/components/thumbnail-grid/grid-layout.tsx
+++ b/components/thumbnail-grid/grid-layout.tsx
@@ -1,66 +1,60 @@
 import { useState, useEffect } from "react";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import Head from "next/head";
 
 import toNumber from "lodash/toNumber";
 import clsx from "clsx";
 
-import Wrapper from "@components/wrapper";
-import PuzzleThumbnail from "@components/puzzle-thumbnail";
-import PuzzlesPagination from "@components/puzzles/pagination";
-import LayoutButtons from "@components/puzzles/layout-buttons";
+import Thumbnail from "@components/thumbnail";
+import Pagination from "@components/thumbnail-grid/pagination";
+import LayoutButtons from "@components/thumbnail-grid/layout-buttons";
 import { PAGINATION_COUNTS } from "@lib/constants";
-import { PuzzleLayoutType } from "@lib/types";
+import { ThumbnailLayoutType } from "@lib/types";
 import { collectionBaseUrl, isTypePack, thumbnailData } from "@lib/utils";
 
 import { GetAllPacksQuery, PublicPuzzlesQuery } from "@lib/generated/graphql";
 
 export interface PageProps {
-  puzzles: PublicPuzzlesQuery["puzzles"] | GetAllPacksQuery["packs"];
+  thumbnailList: PublicPuzzlesQuery["puzzles"] | GetAllPacksQuery["packs"];
   isFirstPage: Boolean;
   isLastPage: Boolean;
 }
 
-const PuzzlesLayout: NextPage<PageProps> = ({
-  puzzles,
+const GridLayout: NextPage<PageProps> = ({
+  thumbnailList,
   isFirstPage,
   isLastPage,
 }) => {
-  const [layout, setLayout] = useState<PuzzleLayoutType>(
-    PuzzleLayoutType.Unknown
+  const [layout, setLayout] = useState<ThumbnailLayoutType>(
+    ThumbnailLayoutType.Unknown
   );
-  const [smallestPuzzleCount] = PAGINATION_COUNTS;
+  const [smallestThumbnailCount] = PAGINATION_COUNTS;
   const { query } = useRouter();
   const [count, page] = query.packsArgs ||
-    query.puzzlesArgs || [smallestPuzzleCount, "1"];
-  const puzzlesCount = toNumber(count);
+    query.puzzlesArgs || [smallestThumbnailCount, "1"];
+  const thumbnailCount = toNumber(count);
   const pageNum = toNumber(page);
-  const isPack = isTypePack(puzzles[0]);
+  const isPack = isTypePack(thumbnailList[0]);
 
   useEffect(() => {
-    const puzzlesLayout = window.localStorage.getItem("puzzlesLayout");
+    const thumbnailLayout = window.localStorage.getItem("thumbnailLayout");
     setLayout(
-      puzzlesLayout ? JSON.parse(puzzlesLayout) : PuzzleLayoutType.List
+      thumbnailLayout ? JSON.parse(thumbnailLayout) : ThumbnailLayoutType.List
     );
   }, []);
 
-  const setView = (gridLayout: PuzzleLayoutType) => {
+  const setView = (gridLayout: ThumbnailLayoutType) => {
     setLayout(gridLayout);
-    window.localStorage.setItem("puzzlesLayout", JSON.stringify(gridLayout));
+    window.localStorage.setItem("thumbnailLayout", JSON.stringify(gridLayout));
   };
 
   return (
-    <Wrapper>
-      <Head>
-        <title>Infinity Keys Puzzles</title>
-      </Head>
-
-      {layout !== PuzzleLayoutType.Unknown && (
+    <>
+      {layout !== ThumbnailLayoutType.Unknown && (
         <div className="w-full">
           <LayoutButtons
-            isGrid={layout === PuzzleLayoutType.Grid}
-            puzzlesCount={puzzlesCount}
+            isGrid={layout === ThumbnailLayoutType.Grid}
+            thumbnailCount={thumbnailCount}
             setView={setView}
             urlBase={collectionBaseUrl(isPack)}
           />
@@ -69,17 +63,17 @@ const PuzzlesLayout: NextPage<PageProps> = ({
             role="list"
             className={clsx(
               "grid grid-cols-1 gap-6 py-8 sm:grid-cols-2",
-              layout === PuzzleLayoutType.Grid
+              layout === ThumbnailLayoutType.Grid
                 ? "md:grid-cols-3 lg:grid-cols-4"
                 : "lg:grid-cols-3 xl:grid-cols-4"
             )}
           >
-            {puzzles.map((puzzle) => {
-              const data = thumbnailData(puzzle);
+            {thumbnailList.map((thumbnail) => {
+              const data = thumbnailData(thumbnail);
               return (
                 <li key={data.id}>
-                  <PuzzleThumbnail
-                    isGrid={layout === PuzzleLayoutType.Grid}
+                  <Thumbnail
+                    isGrid={layout === ThumbnailLayoutType.Grid}
                     id={data.id}
                     name={data.name}
                     url={data.url}
@@ -90,16 +84,16 @@ const PuzzlesLayout: NextPage<PageProps> = ({
             })}
           </ul>
 
-          <PuzzlesPagination
+          <Pagination
             isFirstPage={isFirstPage}
             isLastPage={isLastPage}
             pageNum={pageNum}
-            puzzlesCount={puzzlesCount}
+            thumbnailCount={thumbnailCount}
             urlBase={collectionBaseUrl(isPack)}
           />
         </div>
       )}
-    </Wrapper>
+    </>
   );
 };
-export default PuzzlesLayout;
+export default GridLayout;

--- a/components/thumbnail-grid/grid-layout.tsx
+++ b/components/thumbnail-grid/grid-layout.tsx
@@ -9,7 +9,7 @@ import Thumbnail from "@components/thumbnail";
 import Pagination from "@components/thumbnail-grid/pagination";
 import LayoutButtons from "@components/thumbnail-grid/layout-buttons";
 import { PAGINATION_COUNTS } from "@lib/constants";
-import { ThumbnailLayoutType } from "@lib/types";
+import { ThumbnailGridLayoutType } from "@lib/types";
 import { collectionBaseUrl, isTypePack, thumbnailData } from "@lib/utils";
 
 import { GetAllPacksQuery, PublicPuzzlesQuery } from "@lib/generated/graphql";
@@ -25,8 +25,8 @@ const GridLayout: NextPage<PageProps> = ({
   isFirstPage,
   isLastPage,
 }) => {
-  const [layout, setLayout] = useState<ThumbnailLayoutType>(
-    ThumbnailLayoutType.Unknown
+  const [layout, setLayout] = useState<ThumbnailGridLayoutType>(
+    ThumbnailGridLayoutType.Unknown
   );
   const [smallestThumbnailCount] = PAGINATION_COUNTS;
   const { query } = useRouter();
@@ -37,23 +37,30 @@ const GridLayout: NextPage<PageProps> = ({
   const isPack = isTypePack(thumbnailList[0]);
 
   useEffect(() => {
-    const thumbnailLayout = window.localStorage.getItem("thumbnailLayout");
+    const thumbnailGridLayout = window.localStorage.getItem(
+      "thumbnailGridLayout"
+    );
     setLayout(
-      thumbnailLayout ? JSON.parse(thumbnailLayout) : ThumbnailLayoutType.List
+      thumbnailGridLayout
+        ? JSON.parse(thumbnailGridLayout)
+        : ThumbnailGridLayoutType.List
     );
   }, []);
 
-  const setView = (gridLayout: ThumbnailLayoutType) => {
+  const setView = (gridLayout: ThumbnailGridLayoutType) => {
     setLayout(gridLayout);
-    window.localStorage.setItem("thumbnailLayout", JSON.stringify(gridLayout));
+    window.localStorage.setItem(
+      "thumbnailGridLayout",
+      JSON.stringify(gridLayout)
+    );
   };
 
   return (
     <>
-      {layout !== ThumbnailLayoutType.Unknown && (
+      {layout !== ThumbnailGridLayoutType.Unknown && (
         <div className="w-full">
           <LayoutButtons
-            isGrid={layout === ThumbnailLayoutType.Grid}
+            isGrid={layout === ThumbnailGridLayoutType.Grid}
             thumbnailCount={thumbnailCount}
             setView={setView}
             urlBase={collectionBaseUrl(isPack)}
@@ -63,7 +70,7 @@ const GridLayout: NextPage<PageProps> = ({
             role="list"
             className={clsx(
               "grid grid-cols-1 gap-6 py-8 sm:grid-cols-2",
-              layout === ThumbnailLayoutType.Grid
+              layout === ThumbnailGridLayoutType.Grid
                 ? "md:grid-cols-3 lg:grid-cols-4"
                 : "lg:grid-cols-3 xl:grid-cols-4"
             )}
@@ -73,7 +80,7 @@ const GridLayout: NextPage<PageProps> = ({
               return (
                 <li key={data.id}>
                   <Thumbnail
-                    isGrid={layout === ThumbnailLayoutType.Grid}
+                    isGrid={layout === ThumbnailGridLayoutType.Grid}
                     id={data.id}
                     name={data.name}
                     url={data.url}

--- a/components/thumbnail-grid/layout-buttons.tsx
+++ b/components/thumbnail-grid/layout-buttons.tsx
@@ -5,14 +5,14 @@ import ViewGridIcon from "@heroicons/react/solid/ViewGridIcon";
 
 import Dropdown from "@components/thumbnail-grid/dropdown";
 
-import { ThumbnailLayoutType } from "@lib/types";
+import { ThumbnailGridLayoutType } from "@lib/types";
 import { PAGINATION_COUNTS } from "@lib/constants";
 
 export interface LayoutButtonsProps {
   isGrid: boolean;
   thumbnailCount: number;
   urlBase: string;
-  setView: (gridLayout: ThumbnailLayoutType) => void;
+  setView: (gridLayout: ThumbnailGridLayoutType) => void;
 }
 
 const LayoutButtons = ({
@@ -26,7 +26,7 @@ const LayoutButtons = ({
   return (
     <div className="flex mt-8">
       <button
-        onClick={() => setView(ThumbnailLayoutType.List)}
+        onClick={() => setView(ThumbnailGridLayoutType.List)}
         aria-label="set list view"
         className={clsx(
           "border mr-2 bg-white/10 p-2 rounded-md transition-all duration-200",
@@ -36,7 +36,7 @@ const LayoutButtons = ({
         <ViewListIcon className="h-5 w-5" aria-hidden="true" />
       </button>
       <button
-        onClick={() => setView(ThumbnailLayoutType.Grid)}
+        onClick={() => setView(ThumbnailGridLayoutType.Grid)}
         aria-label="set grid view"
         className={clsx(
           "border bg-white/10 p-2 rounded-md transition-all duration-200 hover:bg-white/20",

--- a/components/thumbnail-grid/layout-buttons.tsx
+++ b/components/thumbnail-grid/layout-buttons.tsx
@@ -3,30 +3,30 @@ import clsx from "clsx";
 import ViewListIcon from "@heroicons/react/solid/ViewListIcon";
 import ViewGridIcon from "@heroicons/react/solid/ViewGridIcon";
 
-import PuzzlesDropdown from "@components/puzzles/dropdown";
+import Dropdown from "@components/thumbnail-grid/dropdown";
 
-import { PuzzleLayoutType } from "@lib/types";
+import { ThumbnailLayoutType } from "@lib/types";
 import { PAGINATION_COUNTS } from "@lib/constants";
 
 export interface LayoutButtonsProps {
   isGrid: boolean;
-  puzzlesCount: number;
+  thumbnailCount: number;
   urlBase: string;
-  setView: (gridLayout: PuzzleLayoutType) => void;
+  setView: (gridLayout: ThumbnailLayoutType) => void;
 }
 
 const LayoutButtons = ({
   isGrid,
-  puzzlesCount,
+  thumbnailCount,
   urlBase,
   setView,
 }: LayoutButtonsProps) => {
-  const [smallestPuzzleCount] = PAGINATION_COUNTS;
+  const [smallestThumbnailCount] = PAGINATION_COUNTS;
 
   return (
     <div className="flex mt-8">
       <button
-        onClick={() => setView(PuzzleLayoutType.List)}
+        onClick={() => setView(ThumbnailLayoutType.List)}
         aria-label="set list view"
         className={clsx(
           "border mr-2 bg-white/10 p-2 rounded-md transition-all duration-200",
@@ -36,7 +36,7 @@ const LayoutButtons = ({
         <ViewListIcon className="h-5 w-5" aria-hidden="true" />
       </button>
       <button
-        onClick={() => setView(PuzzleLayoutType.Grid)}
+        onClick={() => setView(ThumbnailLayoutType.Grid)}
         aria-label="set grid view"
         className={clsx(
           "border bg-white/10 p-2 rounded-md transition-all duration-200 hover:bg-white/20",
@@ -45,9 +45,9 @@ const LayoutButtons = ({
       >
         <ViewGridIcon className="h-5 w-5" aria-hidden="true" />
       </button>
-      <PuzzlesDropdown
+      <Dropdown
         urlBase={urlBase}
-        currentCount={puzzlesCount || smallestPuzzleCount}
+        currentCount={thumbnailCount || smallestThumbnailCount}
       />
     </div>
   );

--- a/components/thumbnail-grid/pagination.tsx
+++ b/components/thumbnail-grid/pagination.tsx
@@ -5,23 +5,24 @@ import ArrowSmLeftIcon from "@heroicons/react/solid/ArrowSmLeftIcon";
 import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
 import { PAGINATION_COUNTS } from "@lib/constants";
 
-export interface PuzzlesPaginationProps {
+export interface PaginationProps {
   isFirstPage: Boolean;
   isLastPage: Boolean;
-  puzzlesCount: number;
+  thumbnailCount: number;
   pageNum: number;
   urlBase: string;
 }
 
-const PuzzlesPagination = ({
+const Pagination = ({
   isFirstPage,
   isLastPage,
-  puzzlesCount,
+  thumbnailCount,
   pageNum,
   urlBase,
-}: PuzzlesPaginationProps) => {
-  const [smallestPuzzleCount] = PAGINATION_COUNTS;
-  const toDefaultPage = puzzlesCount === smallestPuzzleCount && pageNum === 2;
+}: PaginationProps) => {
+  const [smallestThumbnailCount] = PAGINATION_COUNTS;
+  const toDefaultPage =
+    thumbnailCount === smallestThumbnailCount && pageNum === 2;
 
   return (
     <div
@@ -35,7 +36,7 @@ const PuzzlesPagination = ({
           href={
             toDefaultPage
               ? urlBase
-              : `${urlBase}/${puzzlesCount}/${pageNum - 1}`
+              : `${urlBase}/${thumbnailCount}/${pageNum - 1}`
           }
         >
           <a className="previous flex items-center bg-white/10 p-2 rounded-md px-4 py-2 hover:bg-white/20 transition">
@@ -46,7 +47,7 @@ const PuzzlesPagination = ({
       )}
 
       {!isLastPage && (
-        <Link href={`${urlBase}/${puzzlesCount}/${pageNum + 1}`}>
+        <Link href={`${urlBase}/${thumbnailCount}/${pageNum + 1}`}>
           <a className="next flex items-center bg-white/10 p-2 rounded-md px-4 py-2 hover:bg-white/20 transition">
             Next
             <ArrowSmRightIcon className="h-4 w-4 ml-2" aria-hidden="true" />
@@ -57,4 +58,4 @@ const PuzzlesPagination = ({
   );
 };
 
-export default PuzzlesPagination;
+export default Pagination;

--- a/components/thumbnail.tsx
+++ b/components/thumbnail.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 import MinimalKeyLogo from "@components/svg/minimal-key-logo-svg";
 import CloudImage from "./cloud-image";
 
-interface PuzzleThumbProps {
+interface ThumbnailProps {
   id: string;
   name: string;
   url: string;
@@ -13,13 +13,13 @@ interface PuzzleThumbProps {
   cloudinary_id: string;
 }
 
-const PuzzleThumbnail = ({
+const Thumbnail = ({
   name,
   id,
   isGrid,
   url,
   cloudinary_id,
-}: PuzzleThumbProps) => {
+}: ThumbnailProps) => {
   return (
     <div
       className={clsx(
@@ -92,4 +92,4 @@ const PuzzleThumbnail = ({
   );
 };
 
-export default PuzzleThumbnail;
+export default Thumbnail;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,7 +29,7 @@ export interface PuzzleInput {
   puzzleId: string;
 }
 
-export enum ThumbnailLayoutType {
+export enum ThumbnailGridLayoutType {
   Grid = "grid",
   List = "list",
   Unknown = "unknown",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,7 +29,7 @@ export interface PuzzleInput {
   puzzleId: string;
 }
 
-export enum PuzzleLayoutType {
+export enum ThumbnailLayoutType {
   Grid = "grid",
   List = "list",
   Unknown = "unknown",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -46,7 +46,7 @@ export const isTypePack = (
   return (data as ThumbnailPack).pack_name !== undefined;
 };
 
-// normalize pack and puzzle data for PuzzleThumbnail
+// normalize pack and puzzle data for Thumbnail
 export const thumbnailData = (data: ThumbnailPack | ThumbnailPuzzle) => {
   const pack = isTypePack(data);
   // TODO: remove this once packs get nft images

--- a/pages/pack/[packName].tsx
+++ b/pages/pack/[packName].tsx
@@ -4,12 +4,12 @@ import clsx from "clsx";
 import isNumber from "lodash/isNumber";
 
 import Wrapper from "@components/wrapper";
-import PuzzleThumbnail from "@components/puzzle-thumbnail";
+import Thumbnail from "@components/thumbnail";
 import Alert from "@components/alert";
 
 import { gqlApiSdk } from "@lib/server";
 import { GetPuzzlesByPackQuery } from "@lib/generated/graphql";
-import { PuzzleLayoutType } from "@lib/types";
+import { ThumbnailLayoutType } from "@lib/types";
 import { wallet } from "@lib/wallet";
 import useCurrentWidth from "@hooks/useCurrentWidth";
 
@@ -62,7 +62,8 @@ const PacksPage: NextPage<PageProps> = ({ puzzles, puzzlesNftIds, pack }) => {
   const nftId = pack.nftId;
 
   const width = useCurrentWidth();
-  const layout = width < 640 ? PuzzleLayoutType.List : PuzzleLayoutType.Grid;
+  const layout =
+    width < 640 ? ThumbnailLayoutType.List : ThumbnailLayoutType.Grid;
   const [chain, setChain] = useState<number | undefined>();
   const [claimed, setClaimed] = useState<boolean>(false);
   const [account, setAccount] = useState<string>("");
@@ -154,8 +155,8 @@ const PacksPage: NextPage<PageProps> = ({ puzzles, puzzlesNftIds, pack }) => {
               const data = thumbnailData(puzzle);
               return (
                 <li key={data.id}>
-                  <PuzzleThumbnail
-                    isGrid={layout === PuzzleLayoutType.Grid}
+                  <Thumbnail
+                    isGrid={layout === ThumbnailLayoutType.Grid}
                     id={data.id}
                     name={data.name}
                     url={data.url}

--- a/pages/pack/[packName].tsx
+++ b/pages/pack/[packName].tsx
@@ -9,7 +9,7 @@ import Alert from "@components/alert";
 
 import { gqlApiSdk } from "@lib/server";
 import { GetPuzzlesByPackQuery } from "@lib/generated/graphql";
-import { ThumbnailLayoutType } from "@lib/types";
+import { ThumbnailGridLayoutType } from "@lib/types";
 import { wallet } from "@lib/wallet";
 import useCurrentWidth from "@hooks/useCurrentWidth";
 
@@ -63,7 +63,7 @@ const PacksPage: NextPage<PageProps> = ({ puzzles, puzzlesNftIds, pack }) => {
 
   const width = useCurrentWidth();
   const layout =
-    width < 640 ? ThumbnailLayoutType.List : ThumbnailLayoutType.Grid;
+    width < 640 ? ThumbnailGridLayoutType.List : ThumbnailGridLayoutType.Grid;
   const [chain, setChain] = useState<number | undefined>();
   const [claimed, setClaimed] = useState<boolean>(false);
   const [account, setAccount] = useState<string>("");
@@ -156,7 +156,7 @@ const PacksPage: NextPage<PageProps> = ({ puzzles, puzzlesNftIds, pack }) => {
               return (
                 <li key={data.id}>
                   <Thumbnail
-                    isGrid={layout === ThumbnailLayoutType.Grid}
+                    isGrid={layout === ThumbnailGridLayoutType.Grid}
                     id={data.id}
                     name={data.name}
                     url={data.url}

--- a/pages/packs/[[...packsArgs]].tsx
+++ b/pages/packs/[[...packsArgs]].tsx
@@ -3,7 +3,9 @@ import { NextPage } from "next";
 import { gqlApiSdk } from "@lib/server";
 import { GetAllPacksQuery } from "@lib/generated/graphql";
 import { PAGINATION_COUNTS } from "@lib/constants";
-import PuzzlesLayout from "@components/puzzles/layout";
+import GridLayout from "@components/thumbnail-grid/grid-layout";
+import Wrapper from "@components/wrapper";
+import Head from "next/head";
 
 export interface PageProps {
   packs: GetAllPacksQuery["packs"];
@@ -19,11 +21,17 @@ interface PageParams {
 
 const Packs: NextPage<PageProps> = ({ packs, isFirstPage, isLastPage }) => {
   return (
-    <PuzzlesLayout
-      puzzles={packs}
-      isFirstPage={isFirstPage}
-      isLastPage={isLastPage}
-    />
+    <Wrapper>
+      <Head>
+        <title>Infinity Keys Packs</title>
+      </Head>
+
+      <GridLayout
+        thumbnailList={packs}
+        isFirstPage={isFirstPage}
+        isLastPage={isLastPage}
+      />
+    </Wrapper>
   );
 };
 

--- a/pages/puzzles/[[...puzzlesArgs]].tsx
+++ b/pages/puzzles/[[...puzzlesArgs]].tsx
@@ -3,7 +3,9 @@ import { NextPage } from "next";
 import { gqlApiSdk } from "@lib/server";
 import { PublicPuzzlesQuery } from "@lib/generated/graphql";
 import { PAGINATION_COUNTS } from "@lib/constants";
-import PuzzlesLayout from "@components/puzzles/layout";
+import GridLayout from "@components/thumbnail-grid/grid-layout";
+import Wrapper from "@components/wrapper";
+import Head from "next/head";
 
 export interface PageProps {
   puzzles: PublicPuzzlesQuery["puzzles"];
@@ -19,11 +21,17 @@ interface PageParams {
 
 const Puzzles: NextPage<PageProps> = ({ puzzles, isFirstPage, isLastPage }) => {
   return (
-    <PuzzlesLayout
-      puzzles={puzzles}
-      isFirstPage={isFirstPage}
-      isLastPage={isLastPage}
-    />
+    <Wrapper>
+      <Head>
+        <title>Infinity Keys Puzzles</title>
+      </Head>
+
+      <GridLayout
+        thumbnailList={puzzles}
+        isFirstPage={isFirstPage}
+        isLastPage={isLastPage}
+      />
+    </Wrapper>
   );
 };
 


### PR DESCRIPTION
rename grid components so they are not specific to "puzzles." 
update prop names and other variables that should no longer reference "puzzles". 
move wrapper and next head out of grid-layout and into correct pages.