### PR TITLE
ENG-751: link-to-parent-from-puzzle-page

### DIFF
--- a/api/src/graphql/rewardables.sdl.ts
+++ b/api/src/graphql/rewardables.sdl.ts
@@ -19,6 +19,7 @@ export const schema = gql`
     userRewards: [UserReward]!
     asParent: [RewardableConnection]!
     asChild: [RewardableConnection]!
+    asChildPublicParentRewardables: [RewardableConnection]!
     migrateId: String
   }
 

--- a/api/src/services/ik/rewardables/rewardables.ts
+++ b/api/src/services/ik/rewardables/rewardables.ts
@@ -41,9 +41,6 @@ export const rewardableBySlugWithAnonPuzzle: QueryResolvers['rewardableBySlugWit
           isAnon: true,
         },
       },
-      include: {
-        puzzle: true,
-      },
     })
   }
 

--- a/api/src/services/rewardables/rewardables.ts
+++ b/api/src/services/rewardables/rewardables.ts
@@ -66,9 +66,16 @@ export const Rewardable: RewardableRelationResolvers = {
       .userRewards({ where: { userId: context.currentUser.id } })
   },
   asParent: (_obj, { root }) => {
-    return db.rewardable.findUnique({ where: { id: root?.id } }).asParent()
+    return db.rewardable
+      .findUnique({ where: { id: root?.id } })
+      .asParent({ orderBy: { childSortWeight: 'asc' } })
   },
   asChild: (_obj, { root }) => {
     return db.rewardable.findUnique({ where: { id: root?.id } }).asChild()
+  },
+  asChildPublicParentRewardables: (_obj, { root }) => {
+    return db.rewardable
+      .findUnique({ where: { id: root?.id } })
+      .asChild({ where: { parentRewardable: { listPublicly: true } } })
   },
 }

--- a/web/src/components/AnonPuzzleCell/AnonPuzzleCell.tsx
+++ b/web/src/components/AnonPuzzleCell/AnonPuzzleCell.tsx
@@ -9,6 +9,7 @@ export const QUERY = gql`
   query FindAnonRewardablePuzzleBySlug($slug: String!) {
     rewardable: rewardableBySlugWithAnonPuzzle(slug: $slug) {
       id
+      type
       name
       slug
       explanation
@@ -16,8 +17,16 @@ export const QUERY = gql`
       nfts {
         cloudinaryId
       }
+      asChildPublicParentRewardables {
+        parentRewardable {
+          slug
+          name
+          type
+        }
+      }
       puzzle {
         id
+        isAnon
         steps {
           id
           stepSortWeight

--- a/web/src/components/PuzzleLandingLayout/PuzzleLandingLayout.tsx
+++ b/web/src/components/PuzzleLandingLayout/PuzzleLandingLayout.tsx
@@ -1,15 +1,19 @@
-import { PropsWithChildren } from 'react'
+import { Fragment, PropsWithChildren } from 'react'
 
 import { buildUrlString, cloudinaryUrl } from '@infinity-keys/core'
 import { LensShareButton } from '@infinity-keys/react-lens-share-button'
+import capitalize from 'lodash/capitalize'
 import {
   FindAnonRewardablePuzzleBySlug,
   FindRewardablePuzzleBySlug,
 } from 'types/graphql'
 
+import { Link } from '@redwoodjs/router'
+
 import RewardableHeader from 'src/components/RewardableHeader/RewardableHeader'
 import Seo from 'src/components/Seo/Seo'
 import TwitterShare from 'src/components/TwitterShare/TwitterShare'
+import { rewardableLandingRoute } from 'src/lib/urls'
 
 import '@infinity-keys/react-lens-share-button/dist/style.css'
 
@@ -34,7 +38,13 @@ const PuzzleLandingLayout = ({
           rewardable.nfts[0]?.cloudinaryId &&
           cloudinaryUrl(rewardable.nfts[0]?.cloudinaryId, 500, 500, false, 1)
         }
-        url={buildUrlString(`/puzzle/${rewardable.slug}`)}
+        url={buildUrlString(
+          rewardableLandingRoute({
+            slug: rewardable.slug,
+            type: rewardable.type,
+            anonPuzzle: rewardable.puzzle.isAnon,
+          })
+        )}
       />
 
       <div className="puzzle__main w-full px-4 text-center">
@@ -48,17 +58,50 @@ const PuzzleLandingLayout = ({
         {children}
       </div>
 
+      {/* Allows user to navigate to every parent of this puzzle */}
+      {rewardable.asChildPublicParentRewardables.length > 0 && (
+        <div className="text-center text-gray-200">
+          <p>
+            Return to:
+            {rewardable.asChildPublicParentRewardables.map(
+              ({ parentRewardable: { slug, name, type } }, index) => (
+                <Fragment key={slug + type}>
+                  {/* prepend a comma to all but the first item */}
+                  {index ? ', ' : ''}
+                  <Link
+                    to={rewardableLandingRoute({ slug, type })}
+                    className="ml-2 mt-2 inline-block italic transition-colors hover:text-turquoise"
+                  >
+                    {name} {capitalize(type)}
+                  </Link>
+                </Fragment>
+              )
+            )}
+          </p>
+        </div>
+      )}
+
       <div className="flex justify-center gap-4 px-4 pb-9 pt-8">
         <LensShareButton
           postBody={`Can you unlock the ${rewardable.name} puzzle?`}
-          url={buildUrlString(`/puzzle/${rewardable.slug}`)}
+          url={buildUrlString(
+            rewardableLandingRoute({
+              slug: rewardable.slug,
+              type: rewardable.type,
+              anonPuzzle: rewardable.puzzle.isAnon,
+            })
+          )}
           className="text-sm font-medium"
         />
         <TwitterShare
           tweetBody={`Can you unlock the ${
             rewardable.name
           } puzzle? @InfinityKeys\n\n${buildUrlString(
-            `/puzzle/${rewardable.slug}`
+            rewardableLandingRoute({
+              slug: rewardable.slug,
+              type: rewardable.type,
+              anonPuzzle: rewardable.puzzle.isAnon,
+            })
           )}`}
         />
       </div>

--- a/web/src/components/PuzzleLandingLayout/PuzzleLandingLayout.tsx
+++ b/web/src/components/PuzzleLandingLayout/PuzzleLandingLayout.tsx
@@ -13,7 +13,7 @@ import { Link } from '@redwoodjs/router'
 import RewardableHeader from 'src/components/RewardableHeader/RewardableHeader'
 import Seo from 'src/components/Seo/Seo'
 import TwitterShare from 'src/components/TwitterShare/TwitterShare'
-import { rewardableLandingRoute } from 'src/lib/urls'
+import { rewardableLandingRoute } from 'src/lib/urlBuilders'
 
 import '@infinity-keys/react-lens-share-button/dist/style.css'
 
@@ -29,6 +29,15 @@ const PuzzleLandingLayout = ({
   stepParam,
   children,
 }: PuzzleLandingLayoutProps) => {
+  // the full https url to this page
+  const url = buildUrlString(
+    rewardableLandingRoute({
+      slug: rewardable.slug,
+      type: rewardable.type,
+      anonPuzzle: rewardable.puzzle.isAnon,
+    })
+  )
+
   return (
     <>
       <Seo
@@ -38,13 +47,7 @@ const PuzzleLandingLayout = ({
           rewardable.nfts[0]?.cloudinaryId &&
           cloudinaryUrl(rewardable.nfts[0]?.cloudinaryId, 500, 500, false, 1)
         }
-        url={buildUrlString(
-          rewardableLandingRoute({
-            slug: rewardable.slug,
-            type: rewardable.type,
-            anonPuzzle: rewardable.puzzle.isAnon,
-          })
-        )}
+        url={url}
       />
 
       <div className="puzzle__main w-full px-4 text-center">
@@ -58,7 +61,7 @@ const PuzzleLandingLayout = ({
         {children}
       </div>
 
-      {/* Allows user to navigate to every parent of this puzzle */}
+      {/* Allows user to navigate to every public parent of this puzzle */}
       {rewardable.asChildPublicParentRewardables.length > 0 && (
         <div className="text-center text-gray-200">
           <p>
@@ -84,25 +87,11 @@ const PuzzleLandingLayout = ({
       <div className="flex justify-center gap-4 px-4 pb-9 pt-8">
         <LensShareButton
           postBody={`Can you unlock the ${rewardable.name} puzzle?`}
-          url={buildUrlString(
-            rewardableLandingRoute({
-              slug: rewardable.slug,
-              type: rewardable.type,
-              anonPuzzle: rewardable.puzzle.isAnon,
-            })
-          )}
+          url={url}
           className="text-sm font-medium"
         />
         <TwitterShare
-          tweetBody={`Can you unlock the ${
-            rewardable.name
-          } puzzle? @InfinityKeys\n\n${buildUrlString(
-            rewardableLandingRoute({
-              slug: rewardable.slug,
-              type: rewardable.type,
-              anonPuzzle: rewardable.puzzle.isAnon,
-            })
-          )}`}
+          tweetBody={`Can you unlock the ${rewardable.name} puzzle? @InfinityKeys\n\n${url}`}
         />
       </div>
     </>

--- a/web/src/components/RewardablePuzzle/RewardablePuzzleCell/RewardablePuzzleCell.tsx
+++ b/web/src/components/RewardablePuzzle/RewardablePuzzleCell/RewardablePuzzleCell.tsx
@@ -9,15 +9,24 @@ export const QUERY = gql`
   query FindRewardablePuzzleBySlug($slug: String!) {
     rewardable: rewardableBySlug(slug: $slug, type: PUZZLE) {
       id
+      type
       name
       slug
       explanation
       successMessage
+      asChildPublicParentRewardables {
+        parentRewardable {
+          slug
+          name
+          type
+        }
+      }
       nfts {
         cloudinaryId
       }
       puzzle {
         id
+        isAnon
         steps {
           id
           stepSortWeight

--- a/web/src/components/StepsLayout/StepsLayout.tsx
+++ b/web/src/components/StepsLayout/StepsLayout.tsx
@@ -52,15 +52,15 @@ const StepsLayout = ({
               <NftCheckButton step={step} puzzleId={puzzle.id} />
             )}
 
-            <div className="mx-auto mt-12 mb-12 max-w-prose p-4 md:mt-16 md:mb-20">
-              {step.challenge && (
+            {step.challenge && (
+              <div className="mx-auto mt-12 mb-12 max-w-prose p-4 md:mt-16 md:mb-20">
                 <CollapsibleMarkdown
                   title="Challenge"
                   content={step.challenge}
                   defaultOpen
                 />
-              )}
-            </div>
+              </div>
+            )}
           </div>
         )}
       </Suspense>

--- a/web/src/lib/urlBuilders.ts
+++ b/web/src/lib/urlBuilders.ts
@@ -2,7 +2,7 @@ import { RewardableType } from 'types/graphql'
 
 import { routes } from '@redwoodjs/router'
 
-//
+// Creates the landing page routes for our rewardables. Does not handle steps
 export const rewardableLandingRoute = ({
   slug,
   type,

--- a/web/src/lib/urls.ts
+++ b/web/src/lib/urls.ts
@@ -1,0 +1,29 @@
+import { RewardableType } from 'types/graphql'
+
+import { routes } from '@redwoodjs/router'
+
+//
+export const rewardableLandingRoute = ({
+  slug,
+  type,
+  anonPuzzle,
+}: {
+  slug: string
+  type: RewardableType
+  anonPuzzle?: boolean
+}) => {
+  switch (type) {
+    case 'PUZZLE':
+      return anonPuzzle
+        ? routes.anonPuzzleLanding({ slug })
+        : routes.puzzleLanding({ slug })
+    case 'PACK':
+      return routes.packLanding({ slug })
+    // @TODO: enable this when we support bundles
+    // case 'BUNDLE':
+    //   return routes.bundleLanding({ slug })
+
+    default:
+      throw new Error(`rewardableLandingRoute type '${type}' not supported`)
+  }
+}


### PR DESCRIPTION
Link to the puzzle's parents on the puzzle landing page.

![Screenshot 2023-03-06 at 2 54 56 PM](https://user-images.githubusercontent.com/19338130/223244002-68b0af48-4413-407a-8941-7b8aed667c33.png)

Removes `challenge` margin when challenge doesn't exist

![Screenshot 2023-03-06 at 11 42 13 AM](https://user-images.githubusercontent.com/19338130/223244069-7001fa51-6fd3-470e-a920-db807b55303f.png)

Sorts puzzles in the packs landing page

![Untitled](https://user-images.githubusercontent.com/19338130/223244284-710c624c-b5ed-4454-a349-3d808e8e2a6a.png)
