### PR TITLE
button disabled 1 line + text faded

### DIFF
--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -49,9 +49,8 @@ export default function Button({
     [
       variant === 'solid' && {
         'bg-turquoise': true,
-        'bg-turquoise/50': disabled,
-        'text-white hover:text-white': disabled,
-        'border-turquoise hover:border-turquoise': disabled,
+        'bg-turquoise/50 border-turquoise hover:border-turquoise text-white/50 hover:text-white/50':
+          disabled,
       },
       variant === 'outline' && 'text-white hover:bg-turquoise',
       variant === 'warn' &&


### PR DESCRIPTION
this change refactors the <Button> code so the disabled definitions are all in one statement.  Additionally, the button's text is set to 50% opacity whever the button is in a disabled state.