### PR TITLE
'Heroes of Evermore' wraps nicely

### DIFF
--- a/web/src/components/Thumbnail/Thumbnail.tsx
+++ b/web/src/components/Thumbnail/Thumbnail.tsx
@@ -32,7 +32,7 @@ const Thumbnail = ({
     <Link
       to={href}
       className={clsx(
-        'puzzle-thumb break-word relative block w-full max-w-[18rem] cursor-pointer rounded-lg border border-transparent bg-blue-800 shadow transition hover:border-turquoise',
+        'puzzle-thumb relative block w-full max-w-[18rem] cursor-pointer break-words rounded-lg border border-transparent bg-blue-800 shadow transition hover:border-turquoise',
         // progress === ThumbnailProgress.Current
         //   ? 'border-turquoise'
         //   : 'border-transparent',

--- a/web/src/components/Thumbnail/Thumbnail.tsx
+++ b/web/src/components/Thumbnail/Thumbnail.tsx
@@ -32,7 +32,7 @@ const Thumbnail = ({
     <Link
       to={href}
       className={clsx(
-        'puzzle-thumb relative block w-full max-w-[18rem] cursor-pointer break-all rounded-lg border border-transparent bg-blue-800 shadow transition hover:border-turquoise',
+        'puzzle-thumb break-word relative block w-full max-w-[18rem] cursor-pointer rounded-lg border border-transparent bg-blue-800 shadow transition hover:border-turquoise',
         // progress === ThumbnailProgress.Current
         //   ? 'border-turquoise'
         //   : 'border-transparent',


### PR DESCRIPTION
Some of the text is being cut off in the `Bars4Icon` that is in the `<GridLayoutButtons />` component...for example, the last "e" in "Evermore"  this can be solved by using `break-word` instead of `break all`