### PR TITLE
ENG-777: input box autofocus

### DIFF
--- a/web/src/components/NftCheckButton/NftCheckButton.tsx
+++ b/web/src/components/NftCheckButton/NftCheckButton.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { FindStepQuery } from 'types/graphql'
 import { useAccount } from 'wagmi'
 
@@ -49,18 +48,17 @@ const NftCheckButton = ({
             <p className="mt-4 italic text-gray-200">{errorMessage}</p>
           )}
 
-          <div
-            className={clsx(
-              'relative flex justify-center pt-6 text-gray-150',
-              failedAttempt && !errorMessage ? 'opacity-1' : 'opacity-0'
-            )}
-            data-cy="fail_message_check"
-          >
-            <Markdown>
-              {step.failMessage ||
-                'Thats not it. Need help? [Join our discord](https://discord.gg/infinitykeys)'}
-            </Markdown>
-          </div>
+          {failedAttempt && !errorMessage && (
+            <div
+              className={'relative flex justify-center pt-6 text-gray-150'}
+              data-cy="fail_message_check"
+            >
+              <Markdown>
+                {step.failMessage ||
+                  'Thats not it. Need help? [Join our discord](https://discord.gg/infinitykeys)'}
+              </Markdown>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/SimpleTextInput/SimpleTextInput.tsx
+++ b/web/src/components/SimpleTextInput/SimpleTextInput.tsx
@@ -65,20 +65,20 @@ const SimpleTextInput = ({
                 inputProps={loRange(count).map(() => ({
                   className: 'ik-code-input',
                 }))}
+                autoFocus
               />
 
-              <div
-                className={clsx(
-                  'relative flex justify-center pt-6 text-gray-150',
-                  failedAttempt && !errorMessage ? 'opacity-1' : 'opacity-0'
-                )}
-                data-cy="fail_message_check"
-              >
-                <Markdown>
-                  {step.failMessage ||
-                    'Thats not it. Need help? [Join our discord](https://discord.gg/infinitykeys)'}
-                </Markdown>
-              </div>
+              {failedAttempt && !errorMessage && (
+                <div
+                  className={'relative flex justify-center pt-6 text-gray-150'}
+                  data-cy="fail_message_check"
+                >
+                  <Markdown>
+                    {step.failMessage ||
+                      'Thats not it. Need help? [Join our discord](https://discord.gg/infinitykeys)'}
+                  </Markdown>
+                </div>
+              )}
 
               {errorMessage && <p className="">{errorMessage}</p>}
 

--- a/web/src/components/SimpleTextInput/SimpleTextInput.tsx
+++ b/web/src/components/SimpleTextInput/SimpleTextInput.tsx
@@ -1,6 +1,5 @@
 import { FormEvent, useState } from 'react'
 
-import clsx from 'clsx'
 import loRange from 'lodash/range'
 import RICIBs from 'react-individual-character-input-boxes'
 import { FindStepQuery } from 'types/graphql'


### PR DESCRIPTION
autofocuses on input box for simple text steps

removes fail message unless there is a failed attempt. previously it would just make the text transparent, but users could still tab any links inside the text