### PR TITLE
ENG-783: add icons to show pack/puzzle progress

### DIFF
--- a/api/src/services/rewardables/rewardables.ts
+++ b/api/src/services/rewardables/rewardables.ts
@@ -66,9 +66,12 @@ export const Rewardable: RewardableRelationResolvers = {
       .userRewards({ where: { userId: context.currentUser.id } })
   },
   asParent: (_obj, { root }) => {
-    return db.rewardable
-      .findUnique({ where: { id: root?.id } })
-      .asParent({ orderBy: { childSortWeight: 'asc' } })
+    return db.rewardable.findUnique({ where: { id: root?.id } }).asParent({
+      orderBy: [
+        { childSortWeight: 'asc' },
+        { childRewardable: { name: 'asc' } },
+      ],
+    })
   },
   asChild: (_obj, { root }) => {
     return db.rewardable.findUnique({ where: { id: root?.id } }).asChild()

--- a/web/src/components/RewardablePack/RewardablePack/RewardablePack.tsx
+++ b/web/src/components/RewardablePack/RewardablePack/RewardablePack.tsx
@@ -1,4 +1,8 @@
-import { buildUrlString, cloudinaryUrl } from '@infinity-keys/core'
+import {
+  buildUrlString,
+  cloudinaryUrl,
+  ThumbnailProgress,
+} from '@infinity-keys/core'
 import { LensShareButton } from '@infinity-keys/react-lens-share-button'
 import type { FindRewardablePackBySlug } from 'types/graphql'
 
@@ -54,20 +58,27 @@ const Rewardable = ({ rewardable }: Props) => {
         )}
 
         <div className="mx-auto mt-12 flex flex-wrap justify-center gap-4 pb-12 sm:flex-row md:pb-20">
-          {rewardable.asParent.map(({ childRewardable }) => (
-            <Thumbnail
-              key={childRewardable.id}
-              id={childRewardable.id}
-              name={childRewardable.name}
-              href={rewardableLandingRoute({
-                type: childRewardable.type,
-                slug: childRewardable.slug,
-                anonPuzzle: childRewardable.puzzle?.isAnon,
-              })}
-              isGrid={width >= LAYOUT_BREAKPOINT}
-              cloudinaryId={childRewardable.nfts[0]?.cloudinaryId}
-            />
-          ))}
+          {rewardable.asParent.map(({ childRewardable }) => {
+            return (
+              <Thumbnail
+                key={childRewardable.id}
+                id={childRewardable.id}
+                name={childRewardable.name}
+                href={rewardableLandingRoute({
+                  type: childRewardable.type,
+                  slug: childRewardable.slug,
+                  anonPuzzle: childRewardable.puzzle?.isAnon,
+                })}
+                progress={
+                  childRewardable.userRewards.length
+                    ? ThumbnailProgress.Completed
+                    : ThumbnailProgress.Unknown
+                }
+                isGrid={width >= LAYOUT_BREAKPOINT}
+                cloudinaryId={childRewardable.nfts[0]?.cloudinaryId}
+              />
+            )
+          })}
         </div>
       </div>
 

--- a/web/src/components/RewardablePack/RewardablePack/RewardablePack.tsx
+++ b/web/src/components/RewardablePack/RewardablePack/RewardablePack.tsx
@@ -16,6 +16,7 @@ import TwitterShare from 'src/components/TwitterShare/TwitterShare'
 import useCurrentWidth from 'src/hooks/useCurrentWidth'
 import '@infinity-keys/react-lens-share-button/dist/style.css'
 import { rewardableLandingRoute } from 'src/lib/urlBuilders'
+import { useAuth } from '@redwoodjs/auth'
 
 interface Props {
   rewardable: NonNullable<FindRewardablePackBySlug['pack']>
@@ -24,6 +25,7 @@ interface Props {
 const LAYOUT_BREAKPOINT = 768
 
 const Rewardable = ({ rewardable }: Props) => {
+  const { isAuthenticated } = useAuth()
   const width = useCurrentWidth()
 
   // the full https url to this page
@@ -59,6 +61,9 @@ const Rewardable = ({ rewardable }: Props) => {
 
         <div className="mx-auto mt-12 flex flex-wrap justify-center gap-4 pb-12 sm:flex-row md:pb-20">
           {rewardable.asParent.map(({ childRewardable }) => {
+            const solvedArray = childRewardable.puzzle.steps.map(
+              ({ hasUserCompletedStep }) => hasUserCompletedStep
+            )
             return (
               <Thumbnail
                 key={childRewardable.id}
@@ -76,6 +81,7 @@ const Rewardable = ({ rewardable }: Props) => {
                 }
                 isGrid={width >= LAYOUT_BREAKPOINT}
                 cloudinaryId={childRewardable.nfts[0]?.cloudinaryId}
+                solvedArray={isAuthenticated ? solvedArray : []}
               />
             )
           })}

--- a/web/src/components/RewardablePack/RewardablePackCell/RewardablePackCell.tsx
+++ b/web/src/components/RewardablePack/RewardablePackCell/RewardablePackCell.tsx
@@ -27,6 +27,9 @@ export const QUERY = gql`
           slug
           puzzle {
             isAnon
+            steps {
+              hasUserCompletedStep
+            }
           }
           userRewards {
             id

--- a/web/src/components/RewardablePack/RewardablePackCell/RewardablePackCell.tsx
+++ b/web/src/components/RewardablePack/RewardablePackCell/RewardablePackCell.tsx
@@ -28,6 +28,9 @@ export const QUERY = gql`
           puzzle {
             isAnon
           }
+          userRewards {
+            id
+          }
           nfts {
             cloudinaryId
           }

--- a/web/src/components/RewardablesCell/RewardablesCell.tsx
+++ b/web/src/components/RewardablesCell/RewardablesCell.tsx
@@ -19,6 +19,17 @@ export const QUERY = gql`
         nfts {
           cloudinaryId
         }
+        userRewards {
+          id
+        }
+        asParent {
+          childSortWeight
+          childRewardable {
+            userRewards {
+              id
+            }
+          }
+        }
       }
       totalCount
     }

--- a/web/src/components/RewardablesGrid/RewardablesGrid.tsx
+++ b/web/src/components/RewardablesGrid/RewardablesGrid.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react'
+import { useAuth } from '@redwoodjs/auth'
 
 import { PAGINATION_COUNTS } from '@infinity-keys/constants'
-import { buildUrlString, ThumbnailGridLayoutType } from '@infinity-keys/core'
+import {
+  buildUrlString,
+  ThumbnailGridLayoutType,
+  ThumbnailProgress,
+} from '@infinity-keys/core'
 import clsx from 'clsx'
 import loCapitalize from 'lodash/capitalize'
 import type { FindRewardables } from 'types/graphql'
@@ -18,6 +23,7 @@ const RewardablesList = ({
   rewardables,
   totalCount,
 }: FindRewardables['rewardablesCollection']) => {
+  const { isAuthenticated } = useAuth()
   const { page, count } = useParams()
   const [layout, setLayout] = useState<ThumbnailGridLayoutType>(
     ThumbnailGridLayoutType.Unknown
@@ -79,6 +85,10 @@ const RewardablesList = ({
             )}
           >
             {rewardables.map((rewardable) => {
+              const solvedArray = rewardable.asParent.map(
+                ({ childRewardable }) => !!childRewardable.userRewards.length
+              )
+
               return (
                 <li
                   key={rewardable.id}
@@ -94,6 +104,12 @@ const RewardablesList = ({
                       anonPuzzle: rewardable.puzzle?.isAnon,
                     })}
                     cloudinaryId={rewardable.nfts[0]?.cloudinaryId}
+                    progress={
+                      rewardable.userRewards.length
+                        ? ThumbnailProgress.Completed
+                        : ThumbnailProgress.Unknown
+                    }
+                    solvedArray={isAuthenticated ? solvedArray : []}
                   />
                 </li>
               )

--- a/web/src/components/Thumbnail/Thumbnail.tsx
+++ b/web/src/components/Thumbnail/Thumbnail.tsx
@@ -1,5 +1,4 @@
-import LockClosedIcon from '@heroicons/react/24/solid/LockClosedIcon'
-import LockOpenIcon from '@heroicons/react/24/solid/LockOpenIcon'
+import CheckIcon from '@heroicons/react/24/solid/CheckIcon'
 import { ThumbnailProgress } from '@infinity-keys/core'
 import Avatar from 'boring-avatars'
 import clsx from 'clsx'
@@ -46,13 +45,9 @@ const Thumbnail = ({
         }
       )}
     >
-      {progress !== ThumbnailProgress.Unknown && (
-        <span className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full ">
-          {progress === ThumbnailProgress.Completed ? (
-            <LockOpenIcon className="h-3 w-3 text-turquoise" />
-          ) : (
-            <LockClosedIcon className="h-3 w-3 text-turquoise" />
-          )}
+      {progress === ThumbnailProgress.Completed && (
+        <span className="absolute top-1 right-1 flex h-5 w-5 items-center justify-center rounded-full bg-turquoise/30 ">
+          <CheckIcon className="h-3 w-3 text-turquoise" />
         </span>
       )}
 

--- a/web/src/components/Thumbnail/Thumbnail.tsx
+++ b/web/src/components/Thumbnail/Thumbnail.tsx
@@ -1,5 +1,5 @@
-// import LockClosedIcon from '@heroicons/react/24/solid/LockClosedIcon'
-// import LockOpenIcon from '@heroicons/react/24/solid/LockOpenIcon'
+import LockClosedIcon from '@heroicons/react/24/solid/LockClosedIcon'
+import LockOpenIcon from '@heroicons/react/24/solid/LockOpenIcon'
 import { ThumbnailProgress } from '@infinity-keys/core'
 import Avatar from 'boring-avatars'
 import clsx from 'clsx'
@@ -15,6 +15,7 @@ interface ThumbnailProps {
   href: string
   isGrid: boolean
   cloudinaryId?: string
+  solvedArray?: boolean[]
   progress?: ThumbnailProgress
 }
 
@@ -25,7 +26,8 @@ const Thumbnail = ({
   id,
   isGrid,
   href,
-  // progress = ThumbnailProgress.Unknown,
+  solvedArray = [],
+  progress = ThumbnailProgress.Unknown,
   cloudinaryId,
 }: ThumbnailProps) => {
   return (
@@ -33,26 +35,26 @@ const Thumbnail = ({
       to={href}
       className={clsx(
         'puzzle-thumb relative block w-full max-w-[18rem] cursor-pointer break-words rounded-lg border border-transparent bg-blue-800 shadow transition hover:border-turquoise',
-        // progress === ThumbnailProgress.Current
-        //   ? 'border-turquoise'
-        //   : 'border-transparent',
+        progress === ThumbnailProgress.Current
+          ? 'border-turquoise'
+          : 'border-transparent',
         {
           'flex flex-col text-center': isGrid,
-          // 'cursor-pointer transition hover:border-turquoise':
-          //   progress === ThumbnailProgress.Completed,
-          // 'opacity-60 grayscale':
-          //   progress === ThumbnailProgress.NotCompleted ||
-          //   progress === ThumbnailProgress.Unknown,
+          'cursor-pointer transition hover:border-turquoise':
+            progress === ThumbnailProgress.Completed,
+          'opacity-60 grayscale': progress === ThumbnailProgress.NotCompleted,
         }
       )}
     >
-      {/* <span className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full ">
-        {progress === ThumbnailProgress.Completed ? (
-          <LockOpenIcon className="h-3 w-3 text-turquoise" />
-        ) : (
-          <LockClosedIcon className="h-3 w-3 text-turquoise" />
-        )}
-      </span> */}
+      {progress !== ThumbnailProgress.Unknown && (
+        <span className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full ">
+          {progress === ThumbnailProgress.Completed ? (
+            <LockOpenIcon className="h-3 w-3 text-turquoise" />
+          ) : (
+            <LockClosedIcon className="h-3 w-3 text-turquoise" />
+          )}
+        </span>
+      )}
 
       <span
         className={clsx(
@@ -81,30 +83,40 @@ const Thumbnail = ({
             />
           )}
         </span>
-        <h3
-          className={clsx('text-sm font-medium text-gray-200', {
-            'mt-6': isGrid,
-          })}
-        >
-          {name}
-        </h3>
-        <dl
-          className={clsx('flex-grow', {
-            ' mt-1 flex flex-col justify-between': isGrid,
-          })}
-        >
-          <dt className="sr-only">Logo</dt>
-          <dd
-            className={clsx(
-              'flex',
-              isGrid ? 'mt-4 justify-center' : 'justify-end'
-            )}
+        <span>
+          <h3
+            className={clsx('text-sm font-medium text-gray-200', {
+              'mt-6': isGrid,
+            })}
           >
-            <span className="h-8 w-8 text-turquoise">
-              <MinimalKeyLogo />
-            </span>
-          </dd>
-        </dl>
+            {name}
+          </h3>
+          <dl
+            className={clsx('flex-grow', {
+              'flex flex-col justify-between': isGrid,
+            })}
+          >
+            <dt className="sr-only">Logo</dt>
+            <dd
+              className={clsx(
+                'flex',
+                isGrid ? 'mt-4 justify-center' : 'justify-start'
+              )}
+            >
+              {solvedArray.map((solved, i) => (
+                <span
+                  key={i}
+                  className={clsx(
+                    'h-5 w-5 pt-2',
+                    solved ? 'text-turquoise' : 'text-gray-300'
+                  )}
+                >
+                  <MinimalKeyLogo />
+                </span>
+              ))}
+            </dd>
+          </dl>
+        </span>
       </span>
     </Link>
   )


### PR DESCRIPTION
The pack landing page. the icons represent steps in the puzzle
![Screenshot 2023-03-14 at 8 58 31 AM](https://user-images.githubusercontent.com/19338130/225042397-2f46d919-c6ea-4b67-aca3-1d4b59352245.png)

pack grid - grid view
![Screenshot 2023-03-14 at 8 58 11 AM](https://user-images.githubusercontent.com/19338130/225042484-e9f671dd-43da-4832-b11f-6e51e6e3e853.png)

pack grid - list view
![Screenshot 2023-03-14 at 8 58 04 AM](https://user-images.githubusercontent.com/19338130/225042514-65a6fc6a-4c61-4c6b-b49b-ba27504cf9a6.png)

