### PR TITLE
ENG-1079: scroll position fix

### DIFF
--- a/web/src/components/HomeContactForm/HomeContactForm.tsx
+++ b/web/src/components/HomeContactForm/HomeContactForm.tsx
@@ -127,7 +127,7 @@ const HomeContactForm = forwardRef((_props, ref) => {
   }
 
   return (
-    <div className="w-full" ref={localRef}>
+    <div className="w-full scroll-mt-28" ref={localRef}>
       <Fade>
         <Form
           onSubmit={onSubmit}

--- a/web/src/entry.client.tsx
+++ b/web/src/entry.client.tsx
@@ -12,7 +12,7 @@ const redwoodAppElement = document.getElementById('redwood-app')
 if (!redwoodAppElement) {
   throw new Error(
     "Could not find an element with ID 'redwood-app'. Please ensure it exists in your 'web/src/index.html' file."
-  );
+  )
 }
 
 if (redwoodAppElement.children?.length > 0) {

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -172,7 +172,13 @@ const HomePage = () => {
 
   useLayoutEffect(() => {
     if (hash === '#works' && workRef.current) {
-      workRef.current.scrollIntoView({ behavior: 'smooth' })
+      // Wait for mobile nav to remove `overflow: hidden` from html tag
+      // before scrolling to element
+      const timeout = setTimeout(() => {
+        workRef.current?.scrollIntoView({ behavior: 'smooth' })
+      }, 300)
+
+      return () => clearTimeout(timeout)
     }
 
     if (hash === '#waitlist') {
@@ -240,7 +246,7 @@ const HomePage = () => {
 
       <section
         ref={workRef}
-        className="scroll-mt-28s relative z-40 -mt-[100px] bg-gradient-to-b from-white/0 to-white/5"
+        className="relative z-40 -mt-[100px] scroll-mt-28 bg-gradient-to-b from-white/0 to-white/5"
       >
         <Container noPt>
           <div className="flex flex-col items-center gap-2 md:flex-row md:justify-center lg:gap-6">

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -184,7 +184,7 @@ const HomePage = () => {
     <div>
       <Seo title="Home" />
 
-      <div className="relative mx-auto mt-20 flex max-w-8xl flex-col items-center overflow-x-hidden md:mt-0 md:min-h-screen md:flex-row md:justify-between">
+      <div className="relative mx-auto flex max-w-8xl flex-col items-center overflow-x-hidden pt-20 md:mt-0 md:min-h-screen md:flex-row md:justify-between">
         <Container noPx pySm>
           <div className="relative z-10 max-w-xs pr-4 pl-4 md:pr-0 lg:max-w-md lg:pl-12">
             <h1 className="text-shadow-lg text-3xl font-semibold lg:text-5xl xl:text-6xl">
@@ -240,7 +240,7 @@ const HomePage = () => {
 
       <section
         ref={workRef}
-        className="relative z-40 -mt-[100px] bg-gradient-to-b from-white/0 to-white/5"
+        className="scroll-mt-28s relative z-40 -mt-[100px] bg-gradient-to-b from-white/0 to-white/5"
       >
         <Container noPt>
           <div className="flex flex-col items-center gap-2 md:flex-row md:justify-center lg:gap-6">


### PR DESCRIPTION
* Add scroll margin top so the elements aren't partially hidden by the header.
* Fix `#works` not scrolling to content when navigated to via mobile nav.